### PR TITLE
drivers:power:supply:ds28e16: Early init module as possible.

### DIFF
--- a/drivers/power/supply/maxim/ds28e16.c
+++ b/drivers/power/supply/maxim/ds28e16.c
@@ -2151,7 +2151,7 @@ static void __exit ds28e16_exit(void)
 	platform_driver_unregister(&ds28e16_driver);
 }
 
-module_init(ds28e16_init);
+subsys_initcall(ds28e16_init);
 module_exit(ds28e16_exit);
 
 MODULE_AUTHOR("xiaomi Inc.");


### PR DESCRIPTION
* maxim fuelgauge getting fail when to get battery_id from ds28e16.
* so init with device_initcall. it will make sure early init ds28e16. before maxim ic acccess it. https://github.com/GuidixX/kernel_xiaomi_spes-5.15/commit/18fedbdbcc8f1de301b7ae85632e6bb416b14374